### PR TITLE
Add buttons & API endpoints for server log downloads

### DIFF
--- a/cmd/server-manager/views/pages/server/logs.html
+++ b/cmd/server-manager/views/pages/server/logs.html
@@ -7,6 +7,7 @@
     <div class="card card-body bg-light card-logs">
         <pre id="server-logs"></pre>
     </div>
+    <br>
     <a class="btn btn-primary" href="/api/log-download/ServerLog">Download Server Log</a>
 
     <hr>
@@ -16,6 +17,7 @@
     <div class="card card-body bg-light card-logs">
         <pre id="manager-logs"></pre>
     </div>
+    <br>
     <a class="btn btn-primary" href="/api/log-download/ManagerLog">Download Manager Log</a>
 
     <hr>
@@ -25,5 +27,6 @@
     <div class="card card-body bg-light card-logs">
         <pre id="plugin-logs"></pre>
     </div>
+    <br>
     <a class="btn btn-primary" href="/api/log-download/PluginsLog">Download Plugins Log</a>
 {{ end }}

--- a/cmd/server-manager/views/pages/server/logs.html
+++ b/cmd/server-manager/views/pages/server/logs.html
@@ -7,6 +7,7 @@
     <div class="card card-body bg-light card-logs">
         <pre id="server-logs"></pre>
     </div>
+    <a class="btn btn-primary" href="/api/log-download/ServerLog">Download Server Log</a>
 
     <hr>
 
@@ -15,6 +16,7 @@
     <div class="card card-body bg-light card-logs">
         <pre id="manager-logs"></pre>
     </div>
+    <a class="btn btn-primary" href="/api/log-download/ManagerLog">Download Manager Log</a>
 
     <hr>
 
@@ -23,4 +25,5 @@
     <div class="card card-body bg-light card-logs">
         <pre id="plugin-logs"></pre>
     </div>
+    <a class="btn btn-primary" href="/api/log-download/PluginsLog">Download Plugins Log</a>
 {{ end }}

--- a/cmd/server-manager/views/pages/server/logs.html
+++ b/cmd/server-manager/views/pages/server/logs.html
@@ -8,7 +8,7 @@
         <pre id="server-logs"></pre>
     </div>
     <br>
-    <a class="btn btn-primary" href="/api/log-download/ServerLog">Download Server Log</a>
+    <a class="btn btn-primary" href="/api/log-download/server">Download Server Log</a>
 
     <hr>
 
@@ -18,7 +18,7 @@
         <pre id="manager-logs"></pre>
     </div>
     <br>
-    <a class="btn btn-primary" href="/api/log-download/ManagerLog">Download Manager Log</a>
+    <a class="btn btn-primary" href="/api/log-download/manager">Download Manager Log</a>
 
     <hr>
 
@@ -28,5 +28,5 @@
         <pre id="plugin-logs"></pre>
     </div>
     <br>
-    <a class="btn btn-primary" href="/api/log-download/PluginsLog">Download Plugins Log</a>
+    <a class="btn btn-primary" href="/api/log-download/plugins">Download Plugins Log</a>
 {{ end }}

--- a/router.go
+++ b/router.go
@@ -212,6 +212,7 @@ func Router(
 		r.Get("/process/{action}", serverAdministrationHandler.serverProcess)
 		r.Get("/logs", serverAdministrationHandler.logs)
 		r.Get("/api/logs", serverAdministrationHandler.logsAPI)
+		r.Get("/api/log-download/{logFile}", serverAdministrationHandler.logsDownload)
 
 		// championships
 		r.Get("/championships/new", championshipsHandler.createOrEdit)

--- a/server_administration.go
+++ b/server_administration.go
@@ -283,11 +283,11 @@ func (sah *ServerAdministrationHandler) logsDownload(w http.ResponseWriter, r *h
 	logFile := chi.URLParam(r, "logFile")
 	var outputString string
 
-	if logFile == "ServerLog" {
+	if logFile == "server" {
 		outputString = sah.process.Logs()
-	} else if logFile == "ManagerLog" {
+	} else if logFile == "manager" {
 		outputString = logOutput.String()
-	} else if logFile == "PluginsLog" {
+	} else if logFile == "plugins" {
 		outputString = pluginsOutput.String()
 	} else {
 		http.Error(w, http.StatusText(http.StatusNotFound), http.StatusNotFound)

--- a/server_administration.go
+++ b/server_administration.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/go-chi/chi"
 	"github.com/mitchellh/go-wordwrap"
@@ -275,6 +276,34 @@ func (sah *ServerAdministrationHandler) logsAPI(w http.ResponseWriter, r *http.R
 		ManagerLog: logOutput.String(),
 		PluginsLog: pluginsOutput.String(),
 	})
+}
+
+// downloading logfiles
+func (sah *ServerAdministrationHandler) logsDownload(w http.ResponseWriter, r *http.Request) {
+	logFile := chi.URLParam(r, "logFile")
+	var outputString string
+
+	if logFile == "ServerLog" {
+		outputString = sah.process.Logs()
+	} else if logFile == "ManagerLog" {
+		outputString = logOutput.String()
+	} else if logFile == "PluginsLog" {
+		outputString = pluginsOutput.String()
+	} else {
+		http.Error(w, http.StatusText(http.StatusNotFound), http.StatusNotFound)
+		return
+	}
+
+	// tell the browser this is a file download
+	w.Header().Set("Content-Type", "application/octet-stream")
+	w.Header().Set("Content-Disposition", "attachment; filename= \""+logFile+"_"+time.Now().Format(time.RFC3339)+".log\"")
+
+	_, err := w.Write([]byte(outputString))
+
+	if err != nil {
+		logrus.WithError(err).Error("failed to return log " + logFile + " as file via http")
+		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+	}
 }
 
 // serverProcessHandler modifies the server process.


### PR DESCRIPTION
Proposal to address #426, please let me know if this is in line with what you imagined here.

----

Adds a new API endpoint `/api/log-download/{logFile}` and according handler in `ServerAdministratorHandler` which accepts one of the parameters `ServerLog`, `ManagerLog`, and `PluginsLog` (returns 404 otherwise), as well as download buttons linking to each individual logfile on the `/logs` page.

Currently returns each log as a plain text file including the current time in RFC3339 format in the file name, for example `ServerLog_2020-01-31T14_35_07Z.log`.

The new download buttons can be found below each log:

![Screenshot_2020-01-31_](https://user-images.githubusercontent.com/5346077/73549278-96fe4d00-4442-11ea-8395-454c5b94f8ca.png)

