### PR TITLE
Changed DefaultCompress as it was previously deprecated and now removed

### DIFF
--- a/router.go
+++ b/router.go
@@ -66,10 +66,10 @@ func Router(
 	kissMyRankHandler *KissMyRankHandler,
 ) http.Handler {
 	r := chi.NewRouter()
-
+	compressor := middleware.Compress(5)
 	r.Use(middleware.RequestID)
 	r.Use(middleware.RealIP)
-	r.Use(middleware.DefaultCompress)
+	r.Use(compressor)
 	r.Use(panicHandler)
 
 	r.HandleFunc("/login", accountHandler.login)

--- a/router.go
+++ b/router.go
@@ -66,6 +66,7 @@ func Router(
 	kissMyRankHandler *KissMyRankHandler,
 ) http.Handler {
 	r := chi.NewRouter()
+
 	compressor := middleware.Compress(5)
 	r.Use(middleware.RequestID)
 	r.Use(middleware.RealIP)


### PR DESCRIPTION
chi middleware compress no longer has the DefaultCompress function as it was marked deprecated and is now removed. See https://github.com/go-chi/chi/commit/baf4ef5b139e284b297573d89daf587457153aa3.

I have replaced the previous use of DefaultCompress with the equivalent using compress and tested to ensure that the same file types are being sent with compression.