### PR TITLE
use correct car name in live timings (+other misc fixes)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ Fixed:
 * Made the new password screen a bit more visually unique, and added a paragraph to explain to new users that they should set their own password rather than using the default one.
 * Tyres with unsafe characters in the name (e.g. sv60's) should no longer cause issues with the Custom Race form.
 * Updated championship event start Lua plugin to take and return the full event entry list.
+* Fixes an issue where drivers would persist in the connected drivers table in Live Timings when they disconnect without completing a lap.
 
 ---
 

--- a/cmd/server-manager/typescript/src/RaceControl.ts
+++ b/cmd/server-manager/typescript/src/RaceControl.ts
@@ -644,8 +644,8 @@ class LiveTimings implements WebsocketHandler {
             if (this.raceControl.status.ConnectedDrivers) {
                 const driver = this.raceControl.status.ConnectedDrivers.Drivers[closedConnection.DriverGUID];
 
-                if (driver && driver.LoadedTime.toString() === "0001-01-01T00:00:00Z") {
-                    // a driver joined but never loaded. remove them from the connected drivers table.
+                if (driver && (driver.LoadedTime.toString() === "0001-01-01T00:00:00Z" || !driver.TotalNumLaps)) {
+                    // a driver joined but never loaded, or hasn't completed any laps. remove them from the connected drivers table.
                     this.$connectedDriversTable.find("tr[data-guid='" + closedConnection.DriverGUID + "']").remove();
                     this.removeDriverFromAdminSelects(driver.CarInfo)
                 }
@@ -799,7 +799,7 @@ class LiveTimings implements WebsocketHandler {
         }
 
         // car model
-        $tr.find(".driver-car").text(prettifyName(driver.CarInfo.CarModel, true));
+        $tr.find(".driver-car").text(driver.CarInfo.CarName);
 
         if (addingDriverToConnectedTable) {
             let currentLapTimeText = "";

--- a/cmd/server-manager/typescript/src/models/RaceControl.ts
+++ b/cmd/server-manager/typescript/src/models/RaceControl.ts
@@ -188,6 +188,7 @@ class RaceControlDriverMapRaceControlDriverSessionCarInfo {
     CarModel: string;
     CarSkin: string;
     DriverInitials: string;
+    CarName: string;
     EventType: number;
 
     constructor(data?: any) {
@@ -198,6 +199,7 @@ class RaceControlDriverMapRaceControlDriverSessionCarInfo {
         this.CarModel = ('CarModel' in d) ? d.CarModel as string : '';
         this.CarSkin = ('CarSkin' in d) ? d.CarSkin as string : '';
         this.DriverInitials = ('DriverInitials' in d) ? d.DriverInitials as string : '';
+        this.CarName = ('CarName' in d) ? d.CarName as string : '';
         this.EventType = ('EventType' in d) ? d.EventType as number : 0;
     }
 

--- a/cmd/server-manager/views/pages/custom-race/new.html
+++ b/cmd/server-manager/views/pages/custom-race/new.html
@@ -734,7 +734,7 @@
                         </div>
                     {{ end }}
 
-                    {{ if $.IsPremium }}
+                    {{ if and $.IsPremium (not $.IsChampionship) }}
                         <hr>
                     {{ end }}
                 {{ end }}

--- a/content_cars.go
+++ b/content_cars.go
@@ -431,10 +431,8 @@ func (cm *CarManager) LoadCar(name string, tyres Tyres) (*Car, error) {
 		}
 	} else {
 		if os.IsNotExist(err) {
-			if err := os.Mkdir(filepath.Join(carDirectory, "skins"), 0755); err != nil {
+			if err := os.Mkdir(filepath.Join(carDirectory, "skins"), 0755); err != nil && !os.IsNotExist(err) {
 				logrus.WithError(err).Warnf("Could not create skins directory for car: %s", name)
-			} else {
-				logrus.Infof("Created empty skins directory for car: %s", name)
 			}
 		} else {
 			logrus.WithError(err).Warnf("Could not load skins for car: %s", name)

--- a/pkg/udp/model.go
+++ b/pkg/udp/model.go
@@ -133,12 +133,14 @@ func (CollisionWithEnvironment) Event() Event {
 }
 
 type SessionCarInfo struct {
-	CarID          CarID      `json:"CarID"`
-	DriverName     string     `json:"DriverName"`
-	DriverGUID     DriverGUID `json:"DriverGUID"`
-	CarModel       string     `json:"CarModel"`
-	CarSkin        string     `json:"CarSkin"`
-	DriverInitials string     `json:"DriverInitials"`
+	CarID      CarID      `json:"CarID"`
+	DriverName string     `json:"DriverName"`
+	DriverGUID DriverGUID `json:"DriverGUID"`
+	CarModel   string     `json:"CarModel"`
+	CarSkin    string     `json:"CarSkin"`
+
+	DriverInitials string `json:"DriverInitials"`
+	CarName        string `json:"CarName"`
 
 	EventType Event `json:"EventType"`
 }

--- a/race_control.go
+++ b/race_control.go
@@ -588,6 +588,7 @@ func (rc *RaceControl) OnClientConnect(client udp.SessionCarInfo) error {
 
 	client.DriverInitials = driverInitials(client.DriverName)
 	client.DriverName = driverName(client.DriverName)
+	client.CarName = prettifyName(client.CarModel, true)
 
 	var driver *RaceControlDriver
 

--- a/servermanager_config.go
+++ b/servermanager_config.go
@@ -3,6 +3,7 @@ package servermanager
 import (
 	"errors"
 	"fmt"
+	"net/http"
 	"os"
 	"strings"
 	"time"
@@ -90,12 +91,17 @@ func (h *HTTPConfig) createSessionStore() (sessions.Store, error) {
 			return nil, errors.New("servermanager: session store location must be a directory")
 		}
 
-		return sessions.NewFilesystemStore(h.SessionStorePath, []byte(h.SessionKey)), nil
+		fsStore := sessions.NewFilesystemStore(h.SessionStorePath, []byte(h.SessionKey))
+		fsStore.Options.SameSite = http.SameSiteStrictMode
 
+		return fsStore, nil
 	case sessionStoreCookie:
 		fallthrough
 	default:
-		return sessions.NewCookieStore([]byte(h.SessionKey)), nil
+		cookieStore := sessions.NewCookieStore([]byte(h.SessionKey))
+		cookieStore.Options.SameSite = http.SameSiteStrictMode
+
+		return cookieStore, nil
 	}
 }
 


### PR DESCRIPTION
fix an issue where a car that has completed no laps would remain in live timings. set same-site mode for cookie store sessions. remove useless error message when creating car skin directories