### PR TITLE
make.bat files for windows build

### DIFF
--- a/cmd/server-manager/make.bat
+++ b/cmd/server-manager/make.bat
@@ -1,0 +1,60 @@
+@ECHO OFF
+
+set GO111MODULE=on
+set VERSION=dev
+
+IF [%1]==[] (
+    echo "Usage: %0 {clean|run|assets|asset-embed}"
+    GOTO END
+)
+IF %1==clean (
+	CALL :clean
+    GOTO END
+)
+
+IF %1==run (
+	CALL :run
+    GOTO END
+)
+IF %1==assets (
+	CALL :assets
+    GOTO END
+)
+IF %1==asset-embed (
+	CALL :asset-embed
+    GOTO END
+)
+
+echo "Usage: %0 {clean|run|assets|asset-embed}"
+
+
+:END
+EXIT /B %ERRORLEVEL%
+
+:clean
+	DEL /F/Q/S .\server-manager server-manager.exe
+	DEL /F/Q/S .\static\manager.js
+	DEL /F/Q/S build/*.*
+	DEL /F/Q/S .\rsrc.syso
+	DEL /F/Q/S .\views\static_embed.go
+	DEL /F/Q/S .\static\static_embed.go
+	DEL /F/Q/S .\typescript\.gulp-cache
+EXIT /B 0
+
+:run
+	go build -ldflags "-s -w -X github.com/JustaPenguin/assetto-server-manager.BuildVersion=%VERSION% %LDFLAGS%"
+	set FILESYSTEM_HTML=true
+	set DEBUG=true
+	.\server-manager
+EXIT /B 0
+
+:assets
+	cd typescript
+	Call .\make.bat build
+	cd ..
+EXIT /B 0
+
+:asset-embed
+	go get -u github.com/mjibson/esc
+	go generate ./...
+EXIT /B 0

--- a/cmd/server-manager/typescript/make.bat
+++ b/cmd/server-manager/typescript/make.bat
@@ -1,0 +1,43 @@
+@ECHO OFF
+
+
+IF [%1]==[] (
+    echo "Usage: %0 {deps|build|watch}"
+    GOTO END
+)
+
+IF %1==deps (
+	CALL :deps
+    GOTO END
+)
+IF %1==build (
+	CALL :deps
+	CALL :build
+    GOTO END
+)
+
+IF %1==watch (
+	CALL :deps
+	CALL :watch
+    GOTO END
+)
+
+echo "Usage: %0 {deps|build|watch}"
+	
+
+
+:END
+EXIT /B %ERRORLEVEL%
+
+
+:deps
+	Call npm install
+EXIT /B 0
+
+:watch
+  Call ./node_modules/.bin/gulp
+EXIT /B 0
+
+:build
+  Call ./node_modules/.bin/gulp build
+EXIT /B 0

--- a/make.bat
+++ b/make.bat
@@ -1,0 +1,84 @@
+@ECHO OFF
+
+set GO111MODULE=on
+set VERSION=unstable
+
+IF [%1]==[] (
+    echo "Usage: %0 {all|clean|generate|assets|asset-embed|build|run}"
+    GOTO END
+)
+IF %1==all (
+	CALL :clean
+	CALL :assets
+	CALL :build
+    GOTO END
+)
+IF %1==clean (
+	CALL :clean
+    GOTO END
+)
+IF %1==generate (
+	CALL :generate
+    GOTO END
+)
+IF %1==assets (
+	CALL :assets
+    GOTO END
+)
+IF %1==asset-embed (
+	CALL :asset-embed
+    GOTO END
+)
+IF %1==build (
+	CALL :build
+    GOTO END
+)
+IF %1==run (
+	CALL :run
+    GOTO END
+)
+
+echo "Usage: %0 {all|clean|generate|assets|asset-embed|build|run}"
+
+:END
+EXIT /B %ERRORLEVEL%
+
+:clean
+	rm -rf changelog_embed.go
+	cd .\cmd\server-manager
+	Call .\make.bat clean
+	cd ..\..
+EXIT /B 0
+
+:generate
+	go get -u github.com/mjibson/esc
+	go generate ./...
+EXIT /B 0
+
+:assets
+	rm -rf changelog_embed.go
+	cd .\cmd\server-manager
+	Call .\make.bat assets
+	cd ..\..
+EXIT /B 0
+
+:asset-embed
+	rm -rf changelog_embed.go
+	cd .\cmd\server-manager
+	Call .\make.bat asset-embed
+	cd ..\..
+EXIT /B 0
+
+:build
+	rm -rf changelog_embed.go
+	cd .\cmd\server-manager
+	Call .\make.bat build
+	cd ..\..
+EXIT /B 0
+
+:run
+	rm -rf changelog_embed.go
+	cd .\cmd\server-manager
+	Call .\make.bat run
+	cd ..\..
+EXIT /B 0


### PR DESCRIPTION
These make.bat files can be used to build on windows. There is some Make goals I couldn't make but I think they are note mandatory.

Note that on Windows I have this error when compiling:
....\internal\changelog\changelog.go:13:20: undefined: FSByte

So I had to change this function a bit but it's not in the pull request.