### PR TITLE
Graceful plugin and acServer shutdown.

### DIFF
--- a/server_process.go
+++ b/server_process.go
@@ -162,7 +162,7 @@ func (sp *AssettoServerProcess) Stop() error {
 		}
 	}
 
-	timeout := time.After(time.Second * 10)
+	timeout := time.After(time.Second * 60)
 	errCh := make(chan error)
 
 	go func() {

--- a/server_process.go
+++ b/server_process.go
@@ -176,13 +176,15 @@ func (sp *AssettoServerProcess) Stop() error {
 		}
 	}()
 
-	if err := kill(sp.cmd.Process); err != nil {
-		logrus.WithError(err).Error("Could not forcibly kill command")
+	logrus.Infof("Shutting down server process: %d", sp.cmd.Process.Pid)
+	stopErr := stopCommand(sp.cmd, errCh, 30)
+	if stopErr != nil {
+		logrus.WithError(stopErr).Errorf("Failed to stop server process: %d", sp.cmd.Process.Pid)
 	}
 
 	sp.cfn()
 
-	return <-errCh
+	return stopErr
 }
 
 func (sp *AssettoServerProcess) Restart() error {
@@ -572,7 +574,9 @@ func (sp *AssettoServerProcess) onStop() error {
 		return err
 	}
 
-	sp.stopChildProcesses()
+	if err := sp.stopChildProcesses(); err != nil {
+		return err
+	}
 
 	for _, doneCh := range sp.notifyDoneChs {
 		select {
@@ -716,21 +720,24 @@ func (sp *AssettoServerProcess) startChildProcess(wd string, command string) err
 	return nil
 }
 
-func (sp *AssettoServerProcess) stopChildProcesses() {
+func (sp *AssettoServerProcess) stopChildProcesses() error {
 	sp.contentManagerWrapper.Stop()
 
 	for _, command := range sp.extraProcesses {
-		err := kill(command.Process)
-
-		if err != nil {
-			logrus.WithError(err).Errorf("Can't kill process: %d", command.Process.Pid)
-			continue
+		waitDone := make(chan error, 1)
+		go func() {
+			waitDone <- command.Wait()
+		}()
+		if err := stopCommand(command, waitDone, 30); err != nil {
+			if _, isExit := err.(*exec.ExitError); !isExit {
+				name := filepath.Base(command.Path)
+				logrus.WithError(err).Warnf("Command stop problem: %s [pid: %d]", name, command.Process.Pid)
+			}
 		}
-
-		_ = command.Process.Release()
 	}
 
 	sp.extraProcesses = make([]*exec.Cmd, 0)
+	return nil
 }
 
 func (sp *AssettoServerProcess) startUDPListener() error {
@@ -812,4 +819,36 @@ func FreeUDPPort() (int, error) {
 	defer l.Close()
 
 	return l.LocalAddr().(*net.UDPAddr).Port, nil
+}
+
+var ErrCommandUnstopable = errors.New("servermanager: command is unstopable")
+
+func stopCommand(cmd *exec.Cmd, waiter chan error, timeout float32) error {
+	name := filepath.Base(cmd.Path)
+	proc := getProcess(cmd)
+	pid := proc.Pid
+	logrus.Infof("Terminating command: %s [pid: %d]...", name, pid)
+	if err := terminate(proc); err != nil {
+		logrus.WithError(err).Errorf("Failed to terminate command: %s [pid: %d]", name, pid)
+		return err
+	}
+	termWait := timeout / 2
+	killWait := timeout - termWait
+	select {
+	case <-time.After(time.Duration(termWait) * time.Second):
+		logrus.Warnf("Process %d did not terminate after %g seconds. Killing...", pid, termWait)
+		if err := kill(proc); err != nil {
+			logrus.WithError(err).Warnf("Failed to kill command: %s [pid: %d]", name, pid)
+			return err
+		}
+		select {
+		case <-time.After(time.Duration(killWait) * time.Second):
+			logrus.Errorf("Process %d could not be killed after %g seconds.", pid, timeout)
+			return ErrCommandUnstopable
+		case err := <-waiter:
+			return err
+		}
+	case err := <-waiter:
+		return err
+	}
 }

--- a/server_process_windows.go
+++ b/server_process_windows.go
@@ -4,7 +4,6 @@ package servermanager
 
 import (
 	"context"
-	"fmt"
 	"os"
 	"os/exec"
 )

--- a/server_process_windows.go
+++ b/server_process_windows.go
@@ -11,12 +11,19 @@ import (
 
 const ServerExecutablePath = "acServer.exe"
 
-func kill(process *os.Process) error {
-	return exec.Command("TASKKILL", "/T", "/F", "/PID", fmt.Sprintf("%d", process.Pid)).Run()
+func getProcess(cmd *exec.Cmd) *os.Process {
+	return cmd.Process
+}
+
+func terminate(ps *os.Process) error {
+	// Windows does not support SIGINT or SIGTERM, just nuke it..
+	return kill(ps)
+}
+
+func kill(ps *os.Process) error {
+	return ps.Kill()
 }
 
 func buildCommand(ctx context.Context, command string, args ...string) *exec.Cmd {
-	cmd := exec.CommandContext(ctx, command, args...)
-
-	return cmd
+	return exec.CommandContext(ctx, command, args...)
 }

--- a/server_process_windows.go
+++ b/server_process_windows.go
@@ -4,6 +4,7 @@ package servermanager
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"os/exec"
 )
@@ -20,7 +21,8 @@ func terminate(ps *os.Process) error {
 }
 
 func kill(ps *os.Process) error {
-	return ps.Kill()
+	// Process.Kill() is unreliable for Windows.  Use less aesthetic but reliable method...
+	return exec.Command("TASKKILL", "/T", "/F", "/PID", fmt.Sprintf("%d", ps.Pid)).Run()
 }
 
 func buildCommand(ctx context.Context, command string, args ...string) *exec.Cmd {


### PR DESCRIPTION
Refactor the plugin kill call to try a SIGINT for some time then use
SIGKILL as required.  In all cases a cmd.Wait is called which ensures
the process is reaped (e.g no defunct procs).

This change mitigates a plugin restart race conditions where the process
being killed is not fully shutdown before a new one is started.  Ie. Issues
with TCP port bind() calls failing when an existing process was not fully terminated.

Related to #1030 


NOTES: Untested in Windows
DISCLAIMER: My first attempt at using golang.