### PR TITLE
remove watcher limits on car scanning, so multiple cars added at once are detected correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Fixed:
 * The Spectator Car will only be filtered out from Championship Points calculations if Spectator Car is enabled in the Championship settings.
 * Fixes an issue where cars could be duplicated in race setups
 * Fixes a crash that could occur when displaying information about a track.
+* Fixes an issue where multiservers could omit scanning new cars if they were added in groups, rather than one at once. If your server is missing cars in the car list, please "Rebuild Search Index" on the Server Options page!
 
 ---
 

--- a/content_cars.go
+++ b/content_cars.go
@@ -331,7 +331,7 @@ func (cm *CarManager) watchForCarChanges() error {
 		return err
 	}
 
-	w.SetMaxEvents(1)
+	w.SetMaxEvents(0)
 	w.FilterOps(watcher.Create, watcher.Remove)
 	w.AddFilterHook(func(info os.FileInfo, fullPath string) error {
 		if info.IsDir() && info.Name() != "cars" {


### PR DESCRIPTION
fixes #1017