### PR TITLE
open stracker in new tab

### DIFF
--- a/cmd/server-manager/views/pages/live-timing.html
+++ b/cmd/server-manager/views/pages/live-timing.html
@@ -83,7 +83,7 @@
             {{ end }}
 
             {{ if $.IsStrackerEnabled }}
-                <a href="{{ $.STrackerInterfacePublicURL }}" class="btn btn-primary btn-sm mt-1">sTracker</a>
+                <a href="{{ $.STrackerInterfacePublicURL }}" target="_blank" class="btn btn-primary btn-sm mt-1">sTracker</a>
             {{ end }}
 
             {{ if and $.IsKissMyRankEnabled (ne $.KissMyRankWebStatsPublicURL "") }}


### PR DESCRIPTION
STracker button on live-timings page will open in a new tab